### PR TITLE
Added necessary dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN ["cpanm", "Mozilla::CA"]
 RUN ["cpanm", "LWP::UserAgent"]
 RUN ["cpanm", "HTTP::Cookies"]
 RUN ["cpanm", "HTML::Entities"]
+RUN ["cpanm", "Archive::Zip"]
 RUN ["cpanm", "MP3::Tag"]
 RUN ["cpanm", "Getopt::Long::Descriptive"]
 RUN apt-get -y  install libssl-dev


### PR DESCRIPTION
Fixed error 'Failed to extract MP3-Tag-1.15.zip - You need to have unzip or Archive::Zip installed.'